### PR TITLE
Revise the `monitor` implementation

### DIFF
--- a/src/service_client_lib.cc
+++ b/src/service_client_lib.cc
@@ -109,6 +109,8 @@ bool ServiceClient::SendMonitorRequest(const std::string &username,
 
   std::unique_ptr<grpc::ClientReader<chirp::MonitorReply> > reader(stub_->monitor(&context, request));
 
+  std::cout << "Ctrl + C to terminate\n";
+
   chirp::MonitorReply reply;
   while (reader->Read(&reply)) {
     struct ServiceClient::Chirp client_chirp;

--- a/src/service_data_structure.cc
+++ b/src/service_data_structure.cc
@@ -136,7 +136,7 @@ std::set<uint64_t> ServiceDataStructure::UserSession::MonitorFrom(struct timeval
     ok = chirp_connect_backend::GetUser(username, &user);
     CHECK(ok) << "User `" << username << "` should exist.";
 
-    if (timercmp(&(user.last_update_chirp_time), from, >)) {
+    if (timercmp(&(user.last_update_chirp_time), from, >=)) {
       // Do push_backs
       UserChirpList user_chirp_list;
       ok = chirp_connect_backend::GetUserChirpList(user.username, &user_chirp_list);
@@ -147,7 +147,7 @@ std::set<uint64_t> ServiceDataStructure::UserSession::MonitorFrom(struct timeval
         ok = chirp_connect_backend::GetChirp(chirp_id, &chirp);
         CHECK(ok) << "The chirp with chirp_id `" << chirp_id << "` should exist.";
 
-        if (timercmp(&(chirp.time), from, >)) {
+        if (timercmp(&(chirp.time), from, >=) && timercmp(&(chirp.time), &now, <)) {
           ret.insert(chirp_id);
         }
       }


### PR DESCRIPTION
This PR modifies the ```monitor``` implementation so that the server side closes streaming after the client side process is killed. However, I currently find no way to test this, so I still keep the counter in my server implementation to make the testing work.